### PR TITLE
[fix] [issue#1] Class "App\Facades\Schema" not found

### DIFF
--- a/src/Console/DBTruncateCommand.php
+++ b/src/Console/DBTruncateCommand.php
@@ -1,9 +1,9 @@
 <?php
 namespace Blubird\DbTruncate\Console;
 
-use App\Facades\Schema;
-use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Console\Command;
 
 class DBTruncateCommand extends Command
 {


### PR DESCRIPTION
Issue Link: https://github.com/kazi-shahin/db-truncate/issues/1

`php artisan db:truncate`

   Error 

```
  Class "App\Facades\Schema" not found

  at src\Console\DBTruncateCommand.php:41
     37▕      * @return int
     38▕      */
     39▕     public function handle()
     40▕     {
  ➜  41▕         $tableNames = Schema::getConnection()->getDoctrineSchemaManager()->listTableNames();
     42▕
     43▕         if ($this->option('except')) {
     44▕             $excepts = $this->option('except');
     45▕             $this->comment('Skipping tables: ' . $excepts);

  1   \vendor\laravel\framework\src\Illuminate\Container\BoundMethod.php:36
      Amims71\DbTruncate\Console\DBTruncateCommand::handle()

  2   \vendor\laravel\framework\src\Illuminate\Container\Util.php:41
      Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
```