### PR TITLE
[feat]  `--seed` option added to run `db:seed` command

### DIFF
--- a/src/Console/DBTruncateCommand.php
+++ b/src/Console/DBTruncateCommand.php
@@ -12,7 +12,7 @@ class DBTruncateCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'db:truncate {--except= : Tables to exclude from truncation (comma-separated)}';
+    protected $signature = 'db:truncate {--except= : Tables to exclude from truncation (comma-separated)} {--seed : If want to run seed after the truncate}';
 
     /**
      * The console command description.
@@ -58,6 +58,23 @@ class DBTruncateCommand extends Command
 
         $this->comment('Enabling foreign key checks...');
         Schema::enableForeignKeyConstraints();
+        $this->comment('Truncate completed.');
+
+        if ($this->isSeedEnabled()) {
+            $this->dbSeed();
+        }
         return 1;
+    }
+
+    protected function dbSeed()
+    {
+        $this->info('Executing seeds...');
+        $this->call('db:seed');
+        $this->info('Seeding completed.');
+    }
+
+    protected function isSeedEnabled(): bool
+    {
+        return $this->option('seed') == true;
     }
 }

--- a/src/Console/DBTruncateCommand.php
+++ b/src/Console/DBTruncateCommand.php
@@ -66,13 +66,23 @@ class DBTruncateCommand extends Command
         return 1;
     }
 
-    protected function dbSeed()
+    /**
+     * Run the db:seed command
+     *
+     * @return void
+     */
+    protected function dbSeed(): void
     {
         $this->info('Executing seeds...');
         $this->call('db:seed');
         $this->info('Seeding completed.');
     }
 
+    /**
+     * Checks if seed flag is passed
+     *
+     * @return boolean
+     */
     protected function isSeedEnabled(): bool
     {
         return $this->option('seed') == true;


### PR DESCRIPTION
`php artisan db:truncate --seed`

This command will now run the `php artisan db:seed` command after it successfully completes truncating all the tables.